### PR TITLE
Closes #44 - Adds better instance ID validation by making it a dynamic lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ beacon --status "warning" "Disk space below threshold"
 
 ### Environment Variables
 
-- `BEACON_INSTANCE_ID`: Override instance ID detection
 - `BEACON_PROJECT`: Set project name (default: "unknown")
 
 ### Command Line Options
@@ -73,14 +72,16 @@ Usage:
   beacon [message] [flags]
 
 Flags:
-  -f, --fail            Emits a failure event
-  -h, --help            Help for beacon
-      --info            Emits an informational event
-      --instance-id     Specifies the EC2 INSTANCE_ID instead of looking it up
-  -p, --pass            Emits a successful event
-      --project string  Names the PROJECT as a source for the event (default "unknown")
-      --status string   Emits an event with a custom STATUS
-  -v, --version         Version for beacon
+  -c, --config string     Specifies a path to load a config file
+  -f, --fail              Emits a failure event
+      --generate-config   Displays a template for the config file
+  -h, --help              Help for beacon
+      --info              Emits an informational event
+  -p, --pass              Emits a successful event
+      --permissions       Displays IAM permissions required by the application
+      --project string    Names the PROJECT as a source for the event (default "unknown")
+      --status string     Emits an event with a custom STATUS
+  -v, --version           Version for beacon
 ```
 
 ## CloudWatch Events Setup

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,15 +1,10 @@
 package main
 
 const (
-	EnvBeaconInstanceID string = "BEACON_INSTANCE_ID"
-	EnvBeaconProject    string = "BEACON_PROJECT"
+	EnvBeaconProject string = "BEACON_PROJECT"
 )
 
 const (
-	FlagInstanceIDLong    string = "instance-id"
-	FlagInstanceIDDesc    string = "Specifies the EC2 instance ID instead of looking it up with IMDS"
-	FlagInstanceIDDefault string = ""
-
 	FlagProjectLong    string = "project"
 	FlagProjectDesc    string = "Names the PROJECT as a source for the event"
 	FlagProjectDefault string = "unknown"

--- a/cmd/handle_generate_config.go
+++ b/cmd/handle_generate_config.go
@@ -11,8 +11,7 @@ import (
 
 func handleGenerateConfig(ctx context.Context) error {
 	configFile := beacon.Config{
-		InstanceID: "i-abcdef1234",
-		Project:    "example",
+		Project: "example",
 	}
 
 	template, err := yaml.Marshal(configFile)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -5,7 +5,6 @@ import (
 )
 
 func init() {
-	rootCmd.Flags().StringVar(&instanceID, FlagInstanceIDLong, FlagInstanceIDDefault, FlagInstanceIDDesc)
 	rootCmd.Flags().StringVar(&project, FlagProjectLong, FlagProjectDefault, FlagProjectDesc)
 	rootCmd.Flags().StringVarP(&userDataStatus, FlagStatusLong, FlagStatusShort, FlagStatusDefault, FlagStatusDesc)
 	rootCmd.Flags().BoolVarP(&statusFail, FlagFailLong, FlagFailShort, FlagFailDefault, FlagFailDesc)
@@ -16,10 +15,6 @@ func init() {
 	rootCmd.Flags().BoolVar(&generateConfig, FlagGenerateConfigLong, FlagGenerateConfigDefault, FlagGenerateConfigDesc)
 
 	// Support environment variables for instance-id and project
-	if os.Getenv(EnvBeaconInstanceID) != "" && instanceID == FlagInstanceIDDefault {
-		instanceID = os.Getenv(EnvBeaconInstanceID)
-	}
-
 	if os.Getenv(EnvBeaconProject) != "" && project == FlagProjectDefault {
 		project = os.Getenv(EnvBeaconProject)
 	}

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -47,10 +47,6 @@ func handleRoot(cmd *cobra.Command, args []string) error {
 	}
 
 	if beaconConfig != nil {
-		if instanceIDNotProvided() && beaconConfig.InstanceID != "" {
-			instanceID = beaconConfig.InstanceID
-		}
-
 		if project == FlagProjectDefault && beaconConfig.Project != "" {
 			project = beaconConfig.Project
 		}
@@ -63,17 +59,12 @@ func handleRoot(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if instanceIDNotProvided() {
-		instanceID, err = beacon.RetrieveInstanceID(ctx, imds.NewFromConfig(cfg))
-		if err != nil {
-			return err
-		}
-	}
+	instanceARN, err := beacon.RetrieveInstanceARN(ctx, imds.NewFromConfig(cfg))
 
 	emitter := beacon.Emitter{
-		InstanceID: beacon.InstanceID(instanceID),
-		Project:    beacon.Project(project),
-		EBClient:   cloudwatchevents.NewFromConfig(cfg),
+		InstanceARN: instanceARN,
+		Project:     beacon.Project(project),
+		EBClient:    cloudwatchevents.NewFromConfig(cfg),
 	}
 
 	status := chooseStatusMessage()
@@ -85,8 +76,4 @@ func handleRoot(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func instanceIDNotProvided() bool {
-	return instanceID == FlagInstanceIDDefault
 }

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -5,7 +5,6 @@ var (
 	statusFail     bool
 	statusInfo     bool
 	statusPass     bool
-	instanceID     string
 	project        string
 	permissions    bool
 	configFile     string

--- a/config.go
+++ b/config.go
@@ -7,8 +7,7 @@ import (
 
 // Config holds the application configuration
 type Config struct {
-	Project    string `yaml:"project"`
-	InstanceID string `yaml:"instance_id"`
+	Project string `yaml:"project"`
 }
 
 // LoadConfig attempts to load configuration from the given path

--- a/doc.go
+++ b/doc.go
@@ -28,9 +28,9 @@ Beacon can send three types of events:
 Example:
 
 	emitter := beacon.Emitter{
-		InstanceID: beacon.InstanceID("i-1234567890abcdef0"),
-		Project:    beacon.Project("my-project"),
-		EBClient:   cloudwatchevents.NewFromConfig(cfg),
+		InstanceARN: beacon.InstanceARN("arn:aws:ec2:us-east-1:0123456789012:instance/i-1234567890abcdef0"),
+		Project:     beacon.Project("my-project"),
+		EBClient:    cloudwatchevents.NewFromConfig(cfg),
 	}
 
 	// Send a success event

--- a/event.go
+++ b/event.go
@@ -13,8 +13,8 @@ import (
 // Emitter sends events to EventBridge with information about EC2 user
 // data script execution
 type Emitter struct {
-	InstanceID InstanceID
-	Project    Project
+	InstanceARN InstanceARN
+	Project     Project
 
 	EBClient   EventBridgeClient
 	IMDSClient IMDSClient
@@ -38,12 +38,12 @@ func (e Emitter) Emit(ctx context.Context, status Status, message string) error 
 	}
 
 	var resources []string
-	if e.InstanceID != "" {
-		if err := e.InstanceID.Validate(); err != nil {
+	if e.InstanceARN != "" {
+		if err := e.InstanceARN.Validate(); err != nil {
 			return err
 		}
 
-		resources = append(resources, string(e.InstanceID))
+		resources = append(resources, string(e.InstanceARN))
 	}
 
 	input := &cloudwatchevents.PutEventsInput{

--- a/event_test.go
+++ b/event_test.go
@@ -44,8 +44,8 @@ func TestEmitterEmit(t *testing.T) {
 		{
 			name: "Successfully emit event with instance ID provided",
 			emitter: Emitter{
-				InstanceID: "arn:aws:ec2:region:0123456789012:instance/i-12345abcdef",
-				Project:    "test-project",
+				InstanceARN: "arn:aws:ec2:region:0123456789012:instance/i-12345abcdef",
+				Project:     "test-project",
 			},
 			status:  Status(STATUS_INFO),
 			message: "Test message",
@@ -59,8 +59,8 @@ func TestEmitterEmit(t *testing.T) {
 		{
 			name: "Successfully emit event with instance ID fetched",
 			emitter: Emitter{
-				InstanceID: "", // Empty, should use IMDS
-				Project:    "test-project",
+				InstanceARN: "", // Empty, should use IMDS
+				Project:     "test-project",
 			},
 			status:  Status(STATUS_INFO),
 			message: "Test message",
@@ -76,7 +76,9 @@ func TestEmitterEmit(t *testing.T) {
 				imdsClient.GetInstanceIdentityDocumentFunc = func(ctx context.Context, input *imds.GetInstanceIdentityDocumentInput, opts ...func(*imds.Options)) (*imds.GetInstanceIdentityDocumentOutput, error) {
 					return &imds.GetInstanceIdentityDocumentOutput{
 						InstanceIdentityDocument: imds.InstanceIdentityDocument{
-              InstanceID: "arn:aws:ec2:region:0123456789012:instance/i-12345abcdef",
+							AccountID:  "0123456789012",
+							Region:     "us-east-1",
+							InstanceID: "i-12345abcdef",
 						},
 					}, nil
 				}
@@ -86,8 +88,8 @@ func TestEmitterEmit(t *testing.T) {
 		{
 			name: "Fail to send event",
 			emitter: Emitter{
-        InstanceID: "arn:aws:ec2:region:0123456789012:instance/i-12345abcdef",
-				Project:    "test-project",
+				InstanceARN: "arn:aws:ec2:region:0123456789012:instance/i-12345abcdef",
+				Project:     "test-project",
 			},
 			status:  Status(STATUS_INFO),
 			message: "Test message",

--- a/event_test.go
+++ b/event_test.go
@@ -44,7 +44,7 @@ func TestEmitterEmit(t *testing.T) {
 		{
 			name: "Successfully emit event with instance ID provided",
 			emitter: Emitter{
-				InstanceID: "i-12345",
+				InstanceID: "arn:aws:ec2:region:0123456789012:instance/i-12345abcdef",
 				Project:    "test-project",
 			},
 			status:  Status(STATUS_INFO),
@@ -76,7 +76,7 @@ func TestEmitterEmit(t *testing.T) {
 				imdsClient.GetInstanceIdentityDocumentFunc = func(ctx context.Context, input *imds.GetInstanceIdentityDocumentInput, opts ...func(*imds.Options)) (*imds.GetInstanceIdentityDocumentOutput, error) {
 					return &imds.GetInstanceIdentityDocumentOutput{
 						InstanceIdentityDocument: imds.InstanceIdentityDocument{
-							InstanceID: "i-fetched",
+              InstanceID: "arn:aws:ec2:region:0123456789012:instance/i-12345abcdef",
 						},
 					}, nil
 				}
@@ -86,7 +86,7 @@ func TestEmitterEmit(t *testing.T) {
 		{
 			name: "Fail to send event",
 			emitter: Emitter{
-				InstanceID: "i-12345",
+        InstanceID: "arn:aws:ec2:region:0123456789012:instance/i-12345abcdef",
 				Project:    "test-project",
 			},
 			status:  Status(STATUS_INFO),

--- a/imds.go
+++ b/imds.go
@@ -3,21 +3,21 @@ package beacon
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 )
 
-// RetrieveInstanceID gets the current EC2 instance ID from the metadata
-// service.  If the metadata service is unavailable, it returns an error
-// suggesting the use of `--instance-id`.
-func RetrieveInstanceID(ctx context.Context, client IMDSClient) (string, error) {
+// RetrieveInstanceARN gets the current EC2 instance ARN from the metadata
+// service.  If the metadata service is unavailable, it returns an error.
+func RetrieveInstanceARN(ctx context.Context, client IMDSClient) (InstanceARN, error) {
 	// Check if IMDS is available
 	_, err := client.GetMetadata(ctx, &imds.GetMetadataInput{
 		Path: "instance-id",
 	})
 
 	if err != nil {
-		return "", errors.New("cannot lookup instance ID because EC2 metadata service is not available. Use --instance-id")
+		return "", errors.New("ec2 metadata service is not available.")
 	}
 
 	// Get instance identity document
@@ -26,5 +26,11 @@ func RetrieveInstanceID(ctx context.Context, client IMDSClient) (string, error) 
 		return "", err
 	}
 
-	return resp.InstanceIdentityDocument.InstanceID, nil //nolint:all
+	instanceID := resp.InstanceIdentityDocument.InstanceID
+	region := resp.InstanceIdentityDocument.Region
+	accountID := resp.InstanceIdentityDocument.AccountID
+
+	arn := fmt.Sprintf("arn:aws:ec2:%s:%s:instance/%s", region, accountID, instanceID)
+
+	return InstanceARN(arn), nil
 }

--- a/imds_test.go
+++ b/imds_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 )
 
-func TestRetrieveInstanceID(t *testing.T) {
+func TestRetrieveInstanceARN(t *testing.T) {
 	tests := []struct {
 		name             string
 		setupMock        func(*MockIMDSClient)
-		expectedID       string
+		expectedARN      InstanceARN
 		expectError      bool
 		expectedErrorMsg string
 	}{
 		{
-			name: "Successfully retrieve instance ID",
+			name: "Successfully retrieve instance ARN",
 			setupMock: func(mockClient *MockIMDSClient) {
 				mockClient.GetMetadataFunc = func(ctx context.Context, input *imds.GetMetadataInput, opts ...func(*imds.Options)) (*imds.GetMetadataOutput, error) {
 					return &imds.GetMetadataOutput{}, nil
@@ -26,12 +26,14 @@ func TestRetrieveInstanceID(t *testing.T) {
 				mockClient.GetInstanceIdentityDocumentFunc = func(ctx context.Context, input *imds.GetInstanceIdentityDocumentInput, opts ...func(*imds.Options)) (*imds.GetInstanceIdentityDocumentOutput, error) {
 					return &imds.GetInstanceIdentityDocumentOutput{
 						InstanceIdentityDocument: imds.InstanceIdentityDocument{
+							AccountID:  "0123456789012",
+							Region:     "us-east-1",
 							InstanceID: "i-12345abcdef",
 						},
 					}, nil
 				}
 			},
-			expectedID:  "i-12345abcdef",
+			expectedARN: "arn:aws:ec2:us-east-1:0123456789012:instance/i-12345abcdef",
 			expectError: false,
 		},
 		{
@@ -41,9 +43,9 @@ func TestRetrieveInstanceID(t *testing.T) {
 					return nil, errors.New("IMDS not available")
 				}
 			},
-			expectedID:       "",
+			expectedARN:      "",
 			expectError:      true,
-			expectedErrorMsg: "cannot lookup instance ID because EC2 metadata service is not available. Use --instance-id",
+			expectedErrorMsg: "ec2 metadata service is not available.",
 		},
 		{
 			name: "Error getting instance identity document",
@@ -56,7 +58,7 @@ func TestRetrieveInstanceID(t *testing.T) {
 					return nil, errors.New("Failed to get instance identity document")
 				}
 			},
-			expectedID:       "",
+			expectedARN:      "",
 			expectError:      true,
 			expectedErrorMsg: "Failed to get instance identity document",
 		},
@@ -67,7 +69,7 @@ func TestRetrieveInstanceID(t *testing.T) {
 			mockClient := &MockIMDSClient{}
 			tt.setupMock(mockClient)
 
-			instanceID, err := RetrieveInstanceID(context.Background(), mockClient)
+			instanceARN, err := RetrieveInstanceARN(context.Background(), mockClient)
 
 			if tt.expectError {
 				if err == nil {
@@ -79,8 +81,8 @@ func TestRetrieveInstanceID(t *testing.T) {
 				t.Errorf("Expected no error but got: %v", err)
 			}
 
-			if instanceID != tt.expectedID {
-				t.Errorf("Expected instance ID %q, got %q", tt.expectedID, instanceID)
+			if instanceARN != tt.expectedARN {
+				t.Errorf("Expected instance ARN %q, got %q", tt.expectedARN, instanceARN)
 			}
 		})
 	}

--- a/types.go
+++ b/types.go
@@ -27,8 +27,8 @@ type Status string
 // Project represents the project name for event source identification
 type Project string
 
-// InstanceID represents an EC2 instance identifier
-type InstanceID string
+// InstanceARN represents an EC2 instance identifier
+type InstanceARN string
 
 // DetailType represents the EventBridge detail type
 type DetailType string
@@ -52,14 +52,14 @@ func (d DetailType) Validate() error {
 	return nil
 }
 
-func (i InstanceID) Validate() error {
+func (i InstanceARN) Validate() error {
 	size := len(i)
 	if size == 0 {
-		return fmt.Errorf("instance ID cannot be empty")
+		return fmt.Errorf("instance ARN cannot be empty")
 	}
 
 	if size > RESOURCE_ARN_MAX_LENGTH {
-		return fmt.Errorf("instance ID length of %d bytes exceeds %d bytes", size, RESOURCE_ARN_MAX_LENGTH)
+		return fmt.Errorf("instance ARN length of %d bytes exceeds %d bytes", size, RESOURCE_ARN_MAX_LENGTH)
 	}
 
 	arnPattern := regexp.MustCompile(`^arn:aws:ec2:[a-z0-9-]+:[0-9]+:instance/i-[a-z0-9]+$`)

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package beacon
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchevents"
@@ -59,6 +60,12 @@ func (i InstanceID) Validate() error {
 
 	if size > RESOURCE_ARN_MAX_LENGTH {
 		return fmt.Errorf("instance ID length of %d bytes exceeds %d bytes", size, RESOURCE_ARN_MAX_LENGTH)
+	}
+
+	arnPattern := regexp.MustCompile(`^arn:aws:ec2:[a-z0-9-]+:[0-9]+:instance/i-[a-z0-9]+$`)
+
+	if !arnPattern.MatchString(string(i)) {
+		return fmt.Errorf("invalid format. Must be a valid EC2 instance ARN")
 	}
 
 	return nil

--- a/types_test.go
+++ b/types_test.go
@@ -56,42 +56,42 @@ func TestDetailTypeValidate(t *testing.T) {
 	}
 }
 
-func TestInstanceIDValidate(t *testing.T) {
+func TestInstanceARNValidate(t *testing.T) {
 	cases := []struct {
 		name           string
-		instanceID     InstanceID
+		instanceARN    InstanceARN
 		expectedErr    bool
 		expectedErrMsg string
 	}{
 		{
 			"knowngood",
-			InstanceID("arn:aws:ec2:us-east-1:0123456789012:instance/i-abc1234567"),
+			InstanceARN("arn:aws:ec2:us-east-1:0123456789012:instance/i-abc1234567"),
 			false,
 			"",
 		},
 		{
 			"empty",
-			InstanceID(""),
+			InstanceARN(""),
 			true,
-			"instance ID cannot be empty",
+			"instance ARN cannot be empty",
 		},
 		{
 			"at maximum",
-			InstanceID("arn:aws:ec2:us-east-1:0123456789012:instance/i-" + strings.Repeat("a", RESOURCE_ARN_MAX_LENGTH-47)),
+			InstanceARN("arn:aws:ec2:us-east-1:0123456789012:instance/i-" + strings.Repeat("a", RESOURCE_ARN_MAX_LENGTH-47)),
 			false,
 			"",
 		},
 		{
 			"too long",
-			InstanceID("arn:aws:ec2:us-east-1:0123456789012:instance/i-" + strings.Repeat("a", RESOURCE_ARN_MAX_LENGTH-46)),
+			InstanceARN("arn:aws:ec2:us-east-1:0123456789012:instance/i-" + strings.Repeat("a", RESOURCE_ARN_MAX_LENGTH-46)),
 			true,
-			fmt.Sprintf("instance ID length of %d bytes exceeds %d bytes", RESOURCE_ARN_MAX_LENGTH+1, RESOURCE_ARN_MAX_LENGTH),
+			fmt.Sprintf("instance ARN length of %d bytes exceeds %d bytes", RESOURCE_ARN_MAX_LENGTH+1, RESOURCE_ARN_MAX_LENGTH),
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.instanceID.Validate()
+			err := tt.instanceARN.Validate()
 
 			if tt.expectedErr {
 				if err == nil {

--- a/types_test.go
+++ b/types_test.go
@@ -65,7 +65,7 @@ func TestInstanceIDValidate(t *testing.T) {
 	}{
 		{
 			"knowngood",
-			InstanceID("test"),
+			InstanceID("arn:aws:ec2:us-east-1:0123456789012:instance/i-abc1234567"),
 			false,
 			"",
 		},
@@ -77,13 +77,13 @@ func TestInstanceIDValidate(t *testing.T) {
 		},
 		{
 			"at maximum",
-			InstanceID(strings.Repeat("a", RESOURCE_ARN_MAX_LENGTH)),
+			InstanceID("arn:aws:ec2:us-east-1:0123456789012:instance/i-" + strings.Repeat("a", RESOURCE_ARN_MAX_LENGTH-47)),
 			false,
 			"",
 		},
 		{
 			"too long",
-			InstanceID(strings.Repeat("a", RESOURCE_ARN_MAX_LENGTH+1)),
+			InstanceID("arn:aws:ec2:us-east-1:0123456789012:instance/i-" + strings.Repeat("a", RESOURCE_ARN_MAX_LENGTH-46)),
 			true,
 			fmt.Sprintf("instance ID length of %d bytes exceeds %d bytes", RESOURCE_ARN_MAX_LENGTH+1, RESOURCE_ARN_MAX_LENGTH),
 		},


### PR DESCRIPTION
This change also modifies how the instance ID is used.  There is no user-specified instance ID now.  The instance ARN is calculated by using the IMDS.